### PR TITLE
fixed fly.toml file missing

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -11,6 +11,7 @@ primary_region = "lhr"
 
 [env]
 ASPNETCORE_URLS="http://+:8080"
+Google__ClientId="559758667407-k0a5jbbmsabs5v5e6carbuj4md1tluao.apps.googleusercontent.com"
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
Fixed: Error: the config for your app is missing an app name, add an app field to the fly.toml file or specify with the -a flag